### PR TITLE
Hide explicitly instantiated static inline members

### DIFF
--- a/src/Hedgehog/Range.fs
+++ b/src/Hedgehog/Range.fs
@@ -1,6 +1,8 @@
 ﻿namespace Hedgehog
 
 open System
+open System.ComponentModel
+
 open Hedgehog.Numeric
 
 /// Tests are parameterized by the `Size` of the randomly-generated data,
@@ -89,56 +91,67 @@ module Range =
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedInt8 : Range<int8> = constantBounded()
     
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedInt16 : Range<Int16> = constantBounded()
         
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedInt32 : Range<Int32> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedInt64 : Range<Int64> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedUInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedUInt8 : Range<uint8> = constantBounded()
     
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedUInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedUInt16 : Range<UInt16> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedUInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedUInt32 : Range<UInt32> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedUInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedUInt64 : Range<UInt64> = constantBounded()
     
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedFloat")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedFloat : Range<float> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedDouble")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedDouble : Range<double> = constantBounded()
 
     /// Construct a range which is unaffected by the size parameter using the
     /// full range of a data type.
     [<CompiledName("ConstantBoundedDecimal")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __constantBoundedDecimal : Range<decimal> = constantBounded()
             
     //
@@ -208,56 +221,67 @@ module Range =
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromInt8(z,x,y) : Range<int8> = linearFrom z x y
     
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromInt16(z,x,y) : Range<Int16> = linearFrom z x y
         
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromInt32(z,x,y) : Range<Int32> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromInt64(z,x,y) : Range<Int64> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromUInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromUInt8(z,x,y) : Range<uint8> = linearFrom z x y
     
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromUInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromUInt16(z,x,y) : Range<UInt16> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromUInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromUInt32(z,x,y) : Range<UInt32> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromUInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromUInt64(z,x,y) : Range<UInt64> = linearFrom z x y
     
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromFloat")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromFloat(z,x,y) : Range<float> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromDouble")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromDouble(z,x,y) : Range<double> = linearFrom z x y
 
     /// Construct a range which scales the bounds relative to the size
     /// parameter.
     [<CompiledName("LinearFromDecimal")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFromDecimal(z,x,y) : Range<decimal> = linearFrom z x y
 
     /// Construct a range which scales the second bound relative to the size
@@ -269,56 +293,67 @@ module Range =
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearInt8(x,y) : Range<int8> = linear x y
     
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearInt16(x,y) : Range<Int16> = linear x y
         
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearInt32(x,y) : Range<Int32> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearInt64(x,y) : Range<Int64> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearUInt8")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearUInt8(x,y) : Range<uint8> = linear x y
     
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearUInt16")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearUInt16(x,y) : Range<UInt16> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearUInt32")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearUInt32(x,y) : Range<UInt32> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearUInt64")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearUInt64(x,y) : Range<UInt64> = linear x y
     
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearFloat")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearFloat(x,y) : Range<float> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearDouble")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearDouble(z,x,y) : Range<double> = linear x y
 
     /// Construct a range which scales the second bound relative to the size
     /// parameter.
     [<CompiledName("LinearDecimal")>]
+    [<EditorBrowsable(EditorBrowsableState.Never)>]
     let __linearDecimal(z,x,y) : Range<decimal> = linear x y
 
         


### PR DESCRIPTION
So that they don't show up on IntelliSense, as they're specific only for C# callers.